### PR TITLE
Display other arts name

### DIFF
--- a/trpg_bot/player/CthulhuPlayer.py
+++ b/trpg_bot/player/CthulhuPlayer.py
@@ -58,7 +58,16 @@ class CthulhuPlayer(AbstractPlayer):
         self.know_arts = self.extract_table(soup, 'Table_know_arts', 'TKAP[]')
 
     def extract_table(self, soup, table_id, value_name):
-        keys = [key.text if key.text != '' else 'その他' for key in soup.find('table', {'id': table_id}).find_all('th',{})[8:]]
+        elements = soup.find('table', {'id': table_id}).find_all('th',{})[8:]
+        def el2text(el):
+            if el.text == '':
+                return el.find('input')['value'] if el.find('input')['value'] else 'その他'
+            elif el.find('input'):
+                return el.text[:-1] + el.find('input')['value'] + ')'
+            else:
+                return el.text
+
+        keys = list(map(el2text, elements))
         values = [value['value'] for value in soup.find('table', {'id': table_id}).find_all('input', {'name': value_name})]
         return dict(zip(keys, values))
 

--- a/trpg_bot/player/CthulhuPlayer.py
+++ b/trpg_bot/player/CthulhuPlayer.py
@@ -61,10 +61,13 @@ class CthulhuPlayer(AbstractPlayer):
         elements = soup.find('table', {'id': table_id}).find_all('th',{})[8:]
         def el2text(el):
             if el.text == '':
+                # 追加した技能名
                 return el.find('input')['value'] if el.find('input')['value'] else 'その他'
             elif el.find('input'):
+                # 既存の技能名 + (詳細)
                 return el.text[:-1] + el.find('input')['value'] + ')'
             else:
+                # 技能名
                 return el.text
 
         keys = list(map(el2text, elements))

--- a/trpg_bot/player/CthulhuPlayer.py
+++ b/trpg_bot/player/CthulhuPlayer.py
@@ -64,7 +64,7 @@ class CthulhuPlayer(AbstractPlayer):
                 # 追加した技能名
                 return el.find('input')['value'] if el.find('input')['value'] else 'その他'
             elif el.find('input'):
-                # 既存の技能名 + (詳細)
+                # 技能名 + (詳細)
                 return el.text[:-1] + el.find('input')['value'] + ')'
             else:
                 # 技能名

--- a/trpg_bot/player/CthulhuPlayer.py
+++ b/trpg_bot/player/CthulhuPlayer.py
@@ -65,7 +65,7 @@ class CthulhuPlayer(AbstractPlayer):
                 return el.find('input')['value'] if el.find('input')['value'] else 'その他'
             elif el.find('input'):
                 # 技能名 + (詳細)
-                return el.text[:-1] + el.find('input')['value'] + ')'
+                return f"{el.text.replace('()', '')}({el.find('input')['value']})"
             else:
                 # 技能名
                 return el.text


### PR DESCRIPTION
#3 の対応

内包表記で.textのリストを取得するかわりに、一旦htmlのままリスト化したのち、
各要素に関数適用。
・textがあるか(ない場合はその他の技能)、
・textがあるならその中にinputがあるか(ある場合は"母国語()"みたいなやつ)、
・それ以外か(普通の"回避"など)、
で処理を分岐させました。

三項：修正後のstatus表示
「母国語」は技能名のあとに言語名を入れられる技能。
「英語」は追加した技能。
それ以外は既存の機能。
![Screenshot from 2020-05-17 16-31-57](https://user-images.githubusercontent.com/45809545/82138507-fea69f80-985b-11ea-99db-940180d4b8f3.png)

母国語とかは `/1d100<母国語` だけで判定できたい気がしてきたので、
後ろの `()` 内を丸ごと取り除くのがよさげな気がしてきた。
(こいつの母国語なんだっけ？と見に行く手間が生じるが)