### PR TITLE
fecth-depth: 0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+          fetch-depth: 0
     - name: Deploy to Heroku
       env:
         HEROKU_API_TOKEN: ${{ secrets.HEROKU_API_TOKEN }}
         HEROKU_APP_NAME: 'discord-trpg-bot'
       if: github.ref == 'refs/heads/master' && job.status == 'success'
       run: |
-        git push https://heroku:$HEROKU_API_TOKEN@git.heroku.com/$HEROKU_APP_NAME.git HEAD:master
+        git push https://heroku:$HEROKU_API_TOKEN@git.heroku.com/$HEROKU_APP_NAME.git origin/master:master


### PR DESCRIPTION
https://mikecoutermarsh.com/github-actions-deploy-to-heroku/
```
Avatar
gmoney • 5 months ago

Getting a "Push rejected, source repository is a shallow clone" error. Any ideas on how to avoid?

•
Reply
•
Share ›

        −
    Avatar
    Mike Mod gmoney • a month ago

    Hey, just updated the post.

    When using actions/checkout@v2, you need to include `fetch-depth: 0`, so that you checkout all commits.
```