### PR TITLE
HEROKU_SLUG_COMMITに修正

### DIFF
--- a/trpg_bot/trpg_bot.py
+++ b/trpg_bot/trpg_bot.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     REDIS = os.environ['REDIS_URL']
     GLOBAL_CHANNEL_ID = int(os.environ['GLOBAL_CHANNEL_ID'])
     DROPBOX_TOKEN = os.environ['DROPBOX_TOKEN']
-    COMMIT_HASH = os.environ['COMMIT_HASH'] if 'COMMIT_HASH' in os.environ.keys() else 'None'
+    COMMIT_HASH = os.environ['HEROKU_SLUG_COMMIT'] if 'HEROKU_SLUG_COMMIT' in os.environ.keys() else 'None'
 
     client = discord.Client()
     r = redis.from_url(os.environ.get("REDIS_URL"), decode_responses=True)


### PR DESCRIPTION
https://devcenter.heroku.com/articles/dyno-metadata
`heroku labs:enable runtime-dyno-metadata -a discord-trpg-bot` 実行した。
`HEROKU_SLUG_COMMIT`　を参照するように修正。