### PR TITLE
convert_arts_nameメソッドの実装

### DIFF
--- a/trpg_bot/mode/CthulhuMode.py
+++ b/trpg_bot/mode/CthulhuMode.py
@@ -24,7 +24,7 @@ class CthulhuMode(DefaultMode):
             url = self.redis.hget(session, user)
             player = CthulhuPlayer(user, url)
 
-            param_key = player.convert_arts_name(message.content.split('<')[1].strip())
+            param_key = message.content.split('<')[1].strip()
             param_value = player.get(param_key)
             result += f" < {param_key}({param_value})"
         return result, sum_dices

--- a/trpg_bot/mode/CthulhuMode.py
+++ b/trpg_bot/mode/CthulhuMode.py
@@ -24,7 +24,7 @@ class CthulhuMode(DefaultMode):
             url = self.redis.hget(session, user)
             player = CthulhuPlayer(user, url)
 
-            param_key = message.content.split('<')[1].strip()
+            param_key = player.convert_arts_name(message.content.split('<')[1].strip())
             param_value = player.get(param_key)
             result += f" < {param_key}({param_value})"
         return result, sum_dices

--- a/trpg_bot/player/CthulhuPlayer.py
+++ b/trpg_bot/player/CthulhuPlayer.py
@@ -74,7 +74,8 @@ class CthulhuPlayer(AbstractPlayer):
         values = [value['value'] for value in soup.find('table', {'id': table_id}).find_all('input', {'name': value_name})]
         return dict(zip(keys, values))
 
-    def get(self, param):
+    def get(self, input_name):
+        param = self.convert_arts_name(input_name)
         if param == 'SAN':
             return self.status['SAN_LEFT']
         if param in self.status.keys():

--- a/trpg_bot/player/CthulhuPlayer.py
+++ b/trpg_bot/player/CthulhuPlayer.py
@@ -141,3 +141,12 @@ class CthulhuPlayer(AbstractPlayer):
                 f"{commu_status}\n"
                 '【知識技能】\n'
                 f"{know_status}\n")
+
+    # 技能の入力に幅を持たせる
+    def convert_arts_name(self, arts_name):
+        if arts_name == "こぶし" or arts_name == "パンチ":
+            return "こぶし（パンチ）"
+        elif arts_name == "マーシャル":
+            return "マーシャルアーツ"
+        else:
+            return arts_name


### PR DESCRIPTION
#11 の対応
CthulhuPlayerクラスのインスタンスメソッドとして，`convert_arts_name(self, arts_name)`を実装しました．
`arts_name`に技能名の一部（省略版）を渡すと，技能名の全体を返します．

現状では
```
"こぶし"，"パンチ" -> "こぶし（パンチ）"
"マーシャル" -> "マーシャルアーツ"
```
に対応しています．

また，`CthulhuMode.dice()`内でこれを使用し，`param_key`に技能名全体を渡すようにしました．