### PR TITLE
CommandIterpreterの追加

### DIFF
--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -65,7 +65,7 @@ class CommandInterpreterLogic():
     if match_regist:
       return 'regist', *match_regist.groups()
 
-    match_dn = re.match('^/(d\d+.*)', command)
+    match_dn = re.match('^/(d\d+ .*)', command)
     if match_dn:
       return 'dn', *match_dn.groups()
     

--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -8,30 +8,30 @@ class CommandInterpreterLogic():
   def match_ndn(command):
     res = re.search('(\d+)d(\d+)', command)
     if res:
-      return map(int, res.groups())
+      return True, map(int, res.groups())
     else:
-      return 0, 0
+      return False, (0, 0)
   
   def match_const(command):
     res = re.search('(\d+)', command)
     if res:
-      return int(res[0])
+      return True, (int(res[0]),)
     else:
-      return None
+      return False, (0,)
   
   def match_d66(command):
-    res = re.search('/(d66)(.*)', command)
+    res = re.search('/(d66) (.*)', command)
     if res:
-      return res.groups()
+      return True, res.groups()
     else:
-      return None, None
+      return False, (None, None)
   
   def match_ndn_txt(command):
     res = re.search('(\d+d\d+) (.+)', command)
     if res:
-      return res.groups()
+      return True, res.groups()
     else:
-      return None, None
+      return False, (None, None)
 
   def interp_command(message):
     command = message.content

--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -36,40 +36,40 @@ class CommandInterpreterLogic():
   def interp_command(command):
 
     if '/ping' in command:
-      return 'ping', None
+      return 'ping', ()
 
     if '/debug' in command:
-      return 'debug', None
+      return 'debug', ()
     
     if '/redis' in command:
-      return 'redis', None
+      return 'redis', ()
 
     if '/sync' in command:
-      return 'sync', None
+      return 'sync', ()
 
     if '/help' in command:
-      return 'help', None
+      return 'help', ()
 
     if '/status' in command:
-      return 'status', None
+      return 'status', ()
 
     if '/players' in command:
-      return 'players', None
+      return 'players', ()
 
     match_mode = re.match('^/mode (.*)', command)
     if match_mode:
-      return  'mode', *match_mode.groups()
+      return  'mode', match_mode.groups()
 
     match_regist = re.match('^/regist (http.*)', command)
     if match_regist:
-      return 'regist', *match_regist.groups()
+      return 'regist', match_regist.groups()
 
     match_dn = re.match('^/(d\d+ .*)', command)
     if match_dn:
-      return 'dn', *match_dn.groups()
+      return 'dn', match_dn.groups()
     
     match_ndn = re.match('^/(\d+d\d+.*)', command)
     if match_ndn:
-      return 'ndn', *match_ndn.groups()
+      return 'ndn', match_ndn.groups()
     
     return '', None

--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#-*- coding:utf-8 -*-
+
+import re
+
+class CommandInterpreter():
+
+  def parse(message):
+    command = message.content
+
+    if command[:5] == '/ping':
+      return 'ping', None
+
+    if command[:6] == '/debug':
+      return 'debug', None
+    
+    if command[:6] == '/redis':
+      return 'redis', None
+
+    if command[:5] == '/sync':
+      return 'sync', None
+
+    if command[:5] == '/help':
+      return 'help', None
+
+    if command[:7] == '/status':
+      return 'status', None
+
+    if command[:8] == '/players':
+      return 'players', None
+
+    match_mode = re.match('^/mode (.*)', command)
+    if match_mode:
+      return  'mode', *match_mode.groups()
+
+    match_regist = re.match('^/regist (http.*)', command)
+    if match_regist:
+      return 'regist', *match_regist.groups()
+
+    match_dn = re.match('^/(d\d+.*)', command)
+    if match_dn:
+      return 'dn', *match_dn.groups()
+    
+    match_ndn = re.match('^/(\d+d\d+.*)', command)
+    if match_ndn:
+      return 'ndn', *match_ndn.groups()
+    
+    return '', None

--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -36,25 +36,25 @@ class CommandInterpreter():
   def interp_command(message):
     command = message.content
 
-    if command[:5] == '/ping':
+    if '/ping' in command:
       return 'ping', None
 
-    if command[:6] == '/debug':
+    if '/debug' in command:
       return 'debug', None
     
-    if command[:6] == '/redis':
+    if '/redis' in command:
       return 'redis', None
 
-    if command[:5] == '/sync':
+    if '/sync' in command:
       return 'sync', None
 
-    if command[:5] == '/help':
+    if '/help' in command:
       return 'help', None
 
-    if command[:7] == '/status':
+    if '/status' in command:
       return 'status', None
 
-    if command[:8] == '/players':
+    if '/players' in command:
       return 'players', None
 
     match_mode = re.match('^/mode (.*)', command)

--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -3,7 +3,7 @@
 
 import re
 
-class CommandInterpreter():
+class CommandInterpreterLogic():
 
   def match_ndn(command):
     res = re.search('(\d+)d(\d+)', command)

--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -33,8 +33,7 @@ class CommandInterpreterLogic():
     else:
       return False, (None, None)
 
-  def interp_command(message):
-    command = message.content
+  def interp_command(command):
 
     if '/ping' in command:
       return 'ping', None

--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -5,7 +5,35 @@ import re
 
 class CommandInterpreter():
 
-  def parse(message):
+  def match_ndn(command):
+    res = re.search('(\d+)d(\d+)', command)
+    if res:
+      return map(int, res.groups())
+    else:
+      return 0, 0
+  
+  def match_const(command):
+    res = re.search('(\d+)', command)
+    if res:
+      return int(res[0])
+    else:
+      return None
+  
+  def match_d66(command):
+    res = re.search('/(d66)(.*)', command)
+    if res:
+      return res.groups()
+    else:
+      return None, None
+  
+  def match_ndn_txt(command):
+    res = re.search('(\d+d\d+) (.+)', command)
+    if res:
+      return res.groups()
+    else:
+      return None, None
+
+  def interp_command(message):
     command = message.content
 
     if command[:5] == '/ping':

--- a/trpg_bot/mode/DefaultMode.py
+++ b/trpg_bot/mode/DefaultMode.py
@@ -8,7 +8,7 @@ import redis
 from prettytable import PrettyTable
 
 from logic.DiceLogic import DiceLogic
-from logic.CommandInterpreterLogic import CommandInterpreter
+from logic.CommandInterpreterLogic import CommandInterpreterLogic
 
 class DefaultMode:
 
@@ -41,11 +41,11 @@ class DefaultMode:
         dices = []
         terms = message.content.split('+')
         for e in terms:
-            amount, size = CommandInterpreter.match_ndn(e)
+            amount, size = CommandInterpreterLogic.match_ndn(e)
             if amount:
                 dices.append(DiceLogic.roll(amount, size))
                 continue
-            const = CommandInterpreter.match_const(e)
+            const = CommandInterpreterLogic.match_const(e)
             if const:
                 dices.append([const])
 

--- a/trpg_bot/mode/DefaultMode.py
+++ b/trpg_bot/mode/DefaultMode.py
@@ -41,11 +41,11 @@ class DefaultMode:
         dices = []
         terms = message.content.split('+')
         for e in terms:
-            amount, size = CommandInterpreterLogic.match_ndn(e)
-            if amount:
+            is_ndn, (amount, size) = CommandInterpreterLogic.match_ndn(e)
+            if is_ndn:
                 dices.append(DiceLogic.roll(amount, size))
                 continue
-            const = CommandInterpreterLogic.match_const(e)
+            is_const, (const,) = CommandInterpreterLogic.match_const(e)
             if const:
                 dices.append([const])
 

--- a/trpg_bot/mode/DefaultMode.py
+++ b/trpg_bot/mode/DefaultMode.py
@@ -8,6 +8,7 @@ import redis
 from prettytable import PrettyTable
 
 from logic.DiceLogic import DiceLogic
+from logic.CommandInterpreterLogic import CommandInterpreter
 
 class DefaultMode:
 
@@ -40,15 +41,13 @@ class DefaultMode:
         dices = []
         terms = message.content.split('+')
         for e in terms:
-            match_ndn = re.search('(\d+)d(\d+)', e)
-            if match_ndn:
-                amount = int(match_ndn.group(1))
-                size = int(match_ndn.group(2))
+            amount, size = CommandInterpreter.match_ndn(e)
+            if amount:
                 dices.append(DiceLogic.roll(amount, size))
                 continue
-            match_const = re.search('(\d+)', e)
-            if match_const:
-                dices.append([int(match_const.group(1))] if match_const else [])
+            const = CommandInterpreter.match_const(e)
+            if const:
+                dices.append([const])
 
         sum_dices = sum(list(itertools.chain.from_iterable(dices)))
         return f"{sum_dices}    {str(dices)[1:-1]}", sum_dices

--- a/trpg_bot/mode/MayokinMode.py
+++ b/trpg_bot/mode/MayokinMode.py
@@ -6,7 +6,7 @@ import re
 from mode.DefaultMode import DefaultMode
 from logic.DiceListLogic import DiceListLogic
 from logic.DiceLogic import DiceLogic
-from logic.CommandInterpreterLogic import CommandInterpreter
+from logic.CommandInterpreterLogic import CommandInterpreterLogic
 from player.MayokinPlayer import MayokinPlayer
 
 class MayokinMode(DefaultMode):
@@ -22,7 +22,7 @@ class MayokinMode(DefaultMode):
         return player.print()
 
     def dice(self, message):
-        match_d66, name = CommandInterpreter.match_d66(message.content)
+        match_d66, name = CommandInterpreterLogic.match_d66(message.content)
         if match_d66:
             path = f"./trpg_bot/resources/mayokin/{name.strip()}.txt"
             value = DiceLogic.roll_d66()
@@ -30,7 +30,7 @@ class MayokinMode(DefaultMode):
             return res_str, value
 
         res_default, sum_dices = super().dice(message)
-        match_ndn_txt, name = CommandInterpreter.match_ndn_txt(message.content)
+        match_ndn_txt, name = CommandInterpreterLogic.match_ndn_txt(message.content)
         if match_ndn_txt:
             path = f"./trpg_bot/resources/mayokin/{name.strip()}.txt"
             list_item = DiceListLogic.disp(path, sum_dices)

--- a/trpg_bot/mode/MayokinMode.py
+++ b/trpg_bot/mode/MayokinMode.py
@@ -6,6 +6,7 @@ import re
 from mode.DefaultMode import DefaultMode
 from logic.DiceListLogic import DiceListLogic
 from logic.DiceLogic import DiceLogic
+from logic.CommandInterpreterLogic import CommandInterpreter
 from player.MayokinPlayer import MayokinPlayer
 
 class MayokinMode(DefaultMode):
@@ -21,19 +22,17 @@ class MayokinMode(DefaultMode):
         return player.print()
 
     def dice(self, message):
-        match_d66 = re.search('/d66(.*)', message.content)
+        match_d66, name = CommandInterpreter.match_d66(message.content)
         if match_d66:
-            name = match_d66.group(1).strip()
-            path = f"./trpg_bot/resources/mayokin/{name}.txt"
+            path = f"./trpg_bot/resources/mayokin/{name.strip()}.txt"
             value = DiceLogic.roll_d66()
             res_str = DiceListLogic.disp(path, value) if len(name) != 0 else value
             return res_str, value
 
         res_default, sum_dices = super().dice(message)
-        match_ndn = re.search('\d+d\d+ (.+)', message.content)
-        if match_ndn:
-            name = match_ndn.group(1).strip()
-            path = f"./trpg_bot/resources/mayokin/{name}.txt"
+        match_ndn_txt, name = CommandInterpreter.match_ndn_txt(message.content)
+        if match_ndn_txt:
+            path = f"./trpg_bot/resources/mayokin/{name.strip()}.txt"
             list_item = DiceListLogic.disp(path, sum_dices)
             res_str = f"{res_default}\n{list_item}"
             return res_str, sum_dices

--- a/trpg_bot/mode/MayokinMode.py
+++ b/trpg_bot/mode/MayokinMode.py
@@ -22,16 +22,16 @@ class MayokinMode(DefaultMode):
         return player.print()
 
     def dice(self, message):
-        match_d66, name = CommandInterpreterLogic.match_d66(message.content)
-        if match_d66:
+        is_d66, (_, name) = CommandInterpreterLogic.match_d66(message.content)
+        if is_d66:
             path = f"./trpg_bot/resources/mayokin/{name.strip()}.txt"
             value = DiceLogic.roll_d66()
             res_str = DiceListLogic.disp(path, value) if len(name) != 0 else value
             return res_str, value
 
         res_default, sum_dices = super().dice(message)
-        match_ndn_txt, name = CommandInterpreterLogic.match_ndn_txt(message.content)
-        if match_ndn_txt:
+        is_ndn_txt, (_, name) = CommandInterpreterLogic.match_ndn_txt(message.content)
+        if is_ndn_txt:
             path = f"./trpg_bot/resources/mayokin/{name.strip()}.txt"
             list_item = DiceListLogic.disp(path, sum_dices)
             res_str = f"{res_default}\n{list_item}"

--- a/trpg_bot/trpg_bot.py
+++ b/trpg_bot/trpg_bot.py
@@ -9,7 +9,7 @@ import redis
 
 from logic.ModeSelectorLogic import ModeSelectorLogic
 from logic.DropboxLogic import DropboxLogic
-from logic.CommandInterpreterLogic import CommandInterpreter
+from logic.CommandInterpreterLogic import CommandInterpreterLogic
 
 if __name__ == '__main__':
     TOKEN = os.environ['DISCORD_BOT_TOKEN']
@@ -35,7 +35,7 @@ if __name__ == '__main__':
             if message.author.bot:
                 return
 
-            command, *params = CommandInterpreter.interp_command(message)
+            command, *params = CommandInterpreterLogic.interp_command(message)
             
             if command == 'ping':
                 await message.channel.send('pong')

--- a/trpg_bot/trpg_bot.py
+++ b/trpg_bot/trpg_bot.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
             if message.author.bot:
                 return
 
-            command, *params = CommandInterpreter.parse(message)
+            command, *params = CommandInterpreter.interp_command(message)
             
             if command == 'ping':
                 await message.channel.send('pong')

--- a/trpg_bot/trpg_bot.py
+++ b/trpg_bot/trpg_bot.py
@@ -9,6 +9,7 @@ import redis
 
 from logic.ModeSelectorLogic import ModeSelectorLogic
 from logic.DropboxLogic import DropboxLogic
+from logic.CommandInterpreterLogic import CommandInterpreter
 
 def validate_mode(message):
     pattern = '^/mode (.*)'
@@ -46,50 +47,47 @@ if __name__ == '__main__':
             if message.author.bot:
                 return
 
-            if message.content == '/ping':
+            command, *params = CommandInterpreter.parse(message)
+            
+            if command == 'ping':
                 await message.channel.send('pong')
 
-            if message.content == '/debug':
+            if command == 'debug':
                 ls_dropbox = os.listdir('./trpg_bot/resources/mayokin')
                 await message.channel.send(f"```\nrevision: {COMMIT_HASH}\nresources_dropbox: {ls_dropbox}```")
 
-            if message.content == '/redis':
-                reply='\n'
-                for key in r.scan_iter():
-                   reply += f"{key}\n"
-                await message.channel.send(f"```{reply}```")
+            if command == 'redis':
+                reply = '\n'.join([key for key in r.scan_iter()])
+                await message.channel.send(f"```\n{reply}```")
 
-            if message.content == '/sync':
+            if command == 'sync':
                 await message.channel.send('Start syncing...')
                 dbx.sync()
                 await message.channel.send('Dice lists were synced with Dropbox.')
 
-            match_mode = validate_mode(message.content)
-            if match_mode:
-                key = match_mode.group(1)
-                mode = mode_selector.select(message, key)
+            if command == 'mode':
+                mode_name = params[0]
+                mode = mode_selector.select(message, mode_name)
                 await message.channel.send(f"{mode} モードになったよ")
 
-            if message.content == '/help':
-                reply = mode_selector.get(message).help()
-                await message.channel.send(reply)
+            if command == 'help':
+                help = mode_selector.get(message).help()
+                await message.channel.send(help)
 
-            match_regist = validate_regist(message.content)
-            if match_regist:
-                url = match_regist.group(1)
+            if command == 'regist':
+                url = params[0]
                 mode_selector.get(message).regist(message, url)
                 await message.channel.send(f"{message.author.mention} がキャラシートを登録したよ\n=> {url}")
 
-            if message.content == '/players':
+            if command == 'players':
                 table = mode_selector.get(message).players(message)
                 await message.channel.send(f"{message.channel.mention} のキャラシート一覧だよ\n```{table}```")
 
-            if validate_ndn(message.content):
+            if command in ['ndn', 'dn']:
                 result, _ = mode_selector.get(message).dice(message)
-                reply = f"{message.author.mention} がサイコロを振ったよ\n=> {result}"
-                await message.channel.send(reply)
+                await message.channel.send(f"{message.author.mention} がサイコロを振ったよ\n=> {result}")
 
-            if message.content == '/status':
+            if command == 'status':
                 status = mode_selector.get(message).status(message)
                 await message.channel.send(f"{message.author.mention} のキャラシートだよ\n```{status}```")
 

--- a/trpg_bot/trpg_bot.py
+++ b/trpg_bot/trpg_bot.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
             if message.author.bot:
                 return
 
-            command, *params = CommandInterpreterLogic.interp_command(message.command)
+            command, params = CommandInterpreterLogic.interp_command(message.command)
             
             if command == 'ping':
                 await message.channel.send('pong')

--- a/trpg_bot/trpg_bot.py
+++ b/trpg_bot/trpg_bot.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
             if message.author.bot:
                 return
 
-            command, *params = CommandInterpreterLogic.interp_command(message)
+            command, *params = CommandInterpreterLogic.interp_command(message.command)
             
             if command == 'ping':
                 await message.channel.send('pong')

--- a/trpg_bot/trpg_bot.py
+++ b/trpg_bot/trpg_bot.py
@@ -11,18 +11,6 @@ from logic.ModeSelectorLogic import ModeSelectorLogic
 from logic.DropboxLogic import DropboxLogic
 from logic.CommandInterpreterLogic import CommandInterpreter
 
-def validate_mode(message):
-    pattern = '^/mode (.*)'
-    return re.match(pattern, message)
-
-def validate_regist(message):
-    pattern = '^/regist (http.*)'
-    return re.match(pattern, message)
-
-def validate_ndn(message):
-    pattern = '^/.*?(\d*d\d+)'
-    return re.match(pattern, message)
-
 if __name__ == '__main__':
     TOKEN = os.environ['DISCORD_BOT_TOKEN']
     REDIS = os.environ['REDIS_URL']


### PR DESCRIPTION
#13 の対応。コマンドの読み取りを担うCommandInterpreterを追加しました。

`CommandInterpreter.parse(message)` をやると、`(コマンドの種類, その他パラメータ,...)` というtupleが返るようにしてみました。 `trpg_bot` ではこれを `command, *params` が受け取ってます。

==
- 結局.diceや.playerや.statusメソッドにはmessageを渡しており、paramsに入れてる情報はmessageから再構築可能なので、paramsは不要かもしれません。interpreterの段階でmessageの加工まで済ませる手は一応ありますが、そうすると各メソッドの処理がinterpreterでのmessage処理に依存しちゃって微妙という説はあります。