### PR TITLE
マヨキン用txtファイルをzipでDL

### DIFF
--- a/trpg_bot/logic/DropboxLogic.py
+++ b/trpg_bot/logic/DropboxLogic.py
@@ -13,9 +13,9 @@ class DropboxLogic:
     
     def sync(self):
         target_dir = './trpg_bot/resources'
-        if(os.path.exists(target_dir+'/mayokin')):
-            shutil.rmtree(target_dir+'/mayokin')
-        zip_path = target_dir+'/dice_files.zip'
+        if(os.path.exists(f"{target_dir}/mayokin")):
+            shutil.rmtree(f"{target_dir}/mayokin")
+        zip_path = f"{target_dir}/dice_files.zip"
         self.dbx.files_download_zip_to_file(zip_path, '/mayokin')
         with zipfile.ZipFile(zip_path) as zf:
             zf.extractall(target_dir)

--- a/trpg_bot/logic/DropboxLogic.py
+++ b/trpg_bot/logic/DropboxLogic.py
@@ -20,4 +20,5 @@ class DropboxLogic:
         with zipfile.ZipFile(zip_path) as zf:
             zf.extractall(target_dir)
         os.remove(zip_path)
+        print('downloaded txt files.')
 

--- a/trpg_bot/logic/DropboxLogic.py
+++ b/trpg_bot/logic/DropboxLogic.py
@@ -4,19 +4,20 @@
 import shutil
 import os
 import dropbox
+import zipfile
 
 class DropboxLogic:
 
     def __init__(self, token):
         self.dbx = dropbox.Dropbox(token) 
-
+    
     def sync(self):
-        target_dir = './trpg_bot/resources/mayokin'
-        if(os.path.exists(target_dir)):
-            shutil.rmtree(target_dir)
-        os.mkdir(target_dir)
-        entries = self.dbx.files_list_folder('/mayokin').entries
-        for entry in entries:
-            if isinstance(entry, dropbox.files.FileMetadata):
-                self.dbx.files_download_to_file(f"{target_dir}/{entry.name}", entry.path_lower)
-                print(f"downloaded {entry.path_lower}")
+        target_dir = './trpg_bot/resources'
+        if(os.path.exists(target_dir+'/mayokin')):
+            shutil.rmtree(target_dir+'/mayokin')
+        zip_path = target_dir+'/dice_files.zip'
+        self.dbx.files_download_zip_to_file(zip_path, '/mayokin')
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(target_dir)
+        os.remove(zip_path)
+

--- a/trpg_bot/logic/DropboxLogic.py
+++ b/trpg_bot/logic/DropboxLogic.py
@@ -15,7 +15,7 @@ class DropboxLogic:
         target_dir = './trpg_bot/resources'
         if(os.path.exists(f"{target_dir}/mayokin")):
             shutil.rmtree(f"{target_dir}/mayokin")
-        zip_path = f"{target_dir}/dice_files.zip"
+        zip_path = f"{target_dir}/dice_lists.zip"
         self.dbx.files_download_zip_to_file(zip_path, '/mayokin')
         with zipfile.ZipFile(zip_path) as zf:
             zf.extractall(target_dir)

--- a/trpg_bot/trpg_bot.py
+++ b/trpg_bot/trpg_bot.py
@@ -60,6 +60,7 @@ if __name__ == '__main__':
                 await message.channel.send(f"```{reply}```")
 
             if message.content == '/sync':
+                await message.channel.send('Start syncing...')
                 dbx.sync()
                 await message.channel.send('Dice lists were synced with Dropbox.')
 


### PR DESCRIPTION
#25 の対応
DropboxLogic.sync()を更新しました．
以下の通りに動作します．

1. `./trpg_bot/resources`内に`mayokin`ディレクトリがある場合，それを削除
2. `dropbox.files_download_zip_to_file`で`./trpg_bot/resources`にzipファイルをDL
3. zipファイルを解凍し，`./trpg_bot/resources/mayokin`内にtxtファイル群が配置される
4. zipファイルを削除