### PR TITLE
d66単体でもmatchするように修正

### DIFF
--- a/trpg_bot/logic/CommandInterpreterLogic.py
+++ b/trpg_bot/logic/CommandInterpreterLogic.py
@@ -60,7 +60,7 @@ class CommandInterpreterLogic():
     if match_regist:
       return 'regist', match_regist.groups()
 
-    match_dice = re.match('^(/d\d+ .*|/\d+d\d+.*)', command)
+    match_dice = re.match('^(/d\d+.*|/\d+d\d+.*)', command)
     if match_dice:
       return 'dice', self.tokenize_dices(command)
     


### PR DESCRIPTION
#47 の対応。
d66直後にスペースがなくてもdiceにマッチさせる。