### PR TITLE
Fix/enable non regist user to dice

### DIFF
--- a/trpg_bot/player/CthulhuPlayer.py
+++ b/trpg_bot/player/CthulhuPlayer.py
@@ -21,9 +21,12 @@ class CthulhuPlayer(AbstractPlayer):
     commu_arts = {}
     know_arts = {}
 
-    def __init__(self, user, url):
+    def __init__(self, user, url = None):
         self.user = user
         self.url = url
+
+        if url is None:
+            return
 
         res = requests.get(self.url)
         soup = BeautifulSoup(res.text, 'html.parser')

--- a/trpg_bot/player/MayokinPlayer.py
+++ b/trpg_bot/player/MayokinPlayer.py
@@ -17,9 +17,12 @@ class MayokinPlayer(AbstractPlayer):
   profile = {} #class, job
   status = {} 
 
-  def __init__(self, user, url):
+  def __init__(self, user, url = None):
     self.user = user
     self.url = url
+
+    if url is None:
+      return
 
     res = requests.get(self.url)
     soup = BeautifulSoup(res.text, 'html.parser')


### PR DESCRIPTION
#48 の対応。
redisから取得したURLが存在しなかったとき（None）、request/bs4の処理をスキップする。
未registerで能力値参照する場合はenbugしても構わないので、これで十分かなって思いました。