### PR TITLE
インスタンス間で共有されるらしいのでurlがNoneのときは参照系の変数を初期化

### DIFF
--- a/trpg_bot/player/CthulhuPlayer.py
+++ b/trpg_bot/player/CthulhuPlayer.py
@@ -26,6 +26,12 @@ class CthulhuPlayer(AbstractPlayer):
         self.url = url
 
         if url is None:
+            self.status = {}
+            self.battle_arts = {}
+            self.find_arts = {}
+            self.act_arts = {}
+            self.commu_arts = {}
+            self.know_arts = {}
             return
 
         res = requests.get(self.url)

--- a/trpg_bot/player/MayokinPlayer.py
+++ b/trpg_bot/player/MayokinPlayer.py
@@ -22,6 +22,8 @@ class MayokinPlayer(AbstractPlayer):
     self.url = url
 
     if url is None:
+      self.profile = {}
+      self.status = {}
       return
 
     res = requests.get(self.url)


### PR DESCRIPTION
hotfix
クラス内で参照を共有する部分について、適切に初期化するように変更。